### PR TITLE
Revise flash alert in Reservations#Create. Add '.html_safe to 'notice…

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -70,7 +70,7 @@ class ReservationsController < ApplicationController
 
       flash[:notice] = %{
         Congratulations member ##{new_reservation.membership_number}!
-        You've just reserved a #{@my_offer.membership} membership
+        You've just reserved a #{@my_offer.membership} membership. Please go to #{view_context.link_to("the Charges page", new_reservation_charge_path(new_reservation))} to pay.
       }
 
       if new_reservation.membership.price.zero?

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -16,7 +16,7 @@
 %>
 
 <% if notice.present? %>
-  <p class="alert alert-primary alert-dismissible fade show" role="alert"><%= notice %></p>
+  <p class="alert alert-primary alert-dismissible fade show" role="alert"><%= notice.html_safe %></p>
 <% end %>
 
 <% if alert.present? %>


### PR DESCRIPTION
…' in alerts layout.


I'm assuming that this is for use in the developing shopping cart story, because as Staging is currently configured, doing this doesn't make a huge amount of sense.  (As currently configured, the flash alert is giving you a link to the page you're already on.   And that's because, in the Staging version of the site, there isn't actually a route that corresponds to `charges_path`, so I linked to what seemed most appropriate.)   If this *is* supposed to make sense in the current iteration of Staging, then talk to me before merging, because I have totally failed to get it. 