### PR TITLE
Prevent dev:reset:structure from forcing structure.sql to match that …

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -61,7 +61,7 @@ namespace :dev do
   namespace :reset do
     desc "Sets db/structure.sql to the same as master"
     task :structure do
-      system("git checkout --force origin/main db/structure.sql")
+      system("git checkout --force origin/staging db/structure.sql")
       system("git reset db/structure.sql")
     end
   end


### PR DESCRIPTION
…of another, much-diverged branch.

Fixes #21 