### PR TITLE
Delete the tag used in CI testing after pushing  to the PR/branch repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,3 +63,7 @@ jobs:
           docker pull $CONTAINER_TEST_REPOSITORY
           docker tag $CONTAINER_TEST_REPOSITORY $CONTAINER_STAGING_REPOSITORY
           docker push $CONTAINER_STAGING_REPOSITORY
+
+      - name: Clean up the CI testing tag
+        run: |
+          aws ecr batch-delete-image --repository-name wellington --image-ids imageTag=ci-${{ github.sha }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -50,3 +50,7 @@ jobs:
           docker pull $CONTAINER_TEST_REPOSITORY
           docker tag $CONTAINER_TEST_REPOSITORY $CONTAINER_STAGING_REPOSITORY
           docker push $CONTAINER_STAGING_REPOSITORY
+
+      - name: Clean up the CI testing tag
+        run: |
+          aws ecr batch-delete-image --repository-name wellington --image-ids imageTag=ci-${{ github.sha }}


### PR DESCRIPTION
This is necessary because of how ECR lifecycle rules work, namely that if they match *any* tag in the repository, they
delete the image associated with that. That results in the staging/release images expiring, which... well, I don't think
we want that. :D