### PR TITLE
Set the report recipients from a DB table

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@
 exclude: >-
   (?x)^(
       vendor/.*|
-      .*\.lock
+      .*\.lock|
       db/structure.sql
   )$
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ exclude: >-
   (?x)^(
       vendor/.*|
       .*\.lock
+      db/structure.sql
   )$
 repos:
   - repo: meta

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -21,7 +21,11 @@ class ReportMailer < ApplicationMailer
   helper_method :border_styles
 
   def nominations_csv
-    return if $nomination_reports_email.nil?
+    destinations = ReportRecipient.where(report: "nomination").pluck(:email_address)
+    if destinations.empty?
+      puts("No nomination report recipients; skipping")
+      return
+    end
 
     command = Export::NominationCsv.new
     csv = command.call
@@ -38,12 +42,16 @@ class ReportMailer < ApplicationMailer
 
     mail(
       subject: "Nominations export #{date}",
-      to: $nomination_reports_email,
+      to: destinations,
     )
   end
 
   def memberships_csv
-    return if $membership_reports_email.nil?
+    destinations = ReportRecipient.where(report: "membership").pluck(:email_address)
+    if destinations.empty?
+      puts("No membership report recipients; skipping")
+      return
+    end
 
     command = Export::MembershipCsv.new
     csv = command.call
@@ -60,7 +68,7 @@ class ReportMailer < ApplicationMailer
 
     mail(
       subject: "Memberships export #{date}",
-      to: $membership_reports_email,
+      to: destinations,
     )
   end
 

--- a/app/models/report_recipient.rb
+++ b/app/models/report_recipient.rb
@@ -1,0 +1,2 @@
+class ReportRecipient < ApplicationRecord
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,30 +19,36 @@ schedule:
   sync_nominations_to_dave:
     cron: "10 0 * * * America/Los_Angeles" # At 00:10 every day
     class: NominationsTdsSync
+    enabled: false
 
   email_nomination_reports:
     cron: "10 0 * * * America/Los_Angeles" # At 00:10 every day
     class: SendNominationReports
+    enabled: false
 
   email_membership_reports:
-    cron: "0 1 * * 6 Pacific/Auckland" # At 01:00 on Saturday
+    cron: "0 1 * * 6 America/Los_Angeles" # At 01:00 on Saturday
     class: SendMembershipReports
 
   # TODO maybe it would have been better to use this http://localhost:3000/sidekiq/scheduled
   # This job returns early if you're not close to 72 hours of nomination close
   # It runs a lot so that the reminder is timely
   email_nomination_reminder_3_days:
-    cron: "0 * * * * Pacific/Auckland" # Every hour on the hour
+    cron: "0 * * * * America/Los_Angeles" # Every hour on the hour
     class: NominationReminderMassMailout
+    enabled: false
 
   email_nomination_ballot_summaries:
-    cron: "*/30 * * * * Pacific/Auckland" # Runs every half an hour
+    cron: "*/30 * * * * America/Los_Angeles" # Runs every half an hour
     class: SendNominationSummaries
+    enabled: false
 
   email_voting_reminder_3_days:
-    cron: "0 * * * * Pacific/Auckland" # Every hour on the hour
+    cron: "0 * * * * America/Los_Angeles" # Every hour on the hour
     class: RankReminderMassMailout
+    enabled: false
 
   email_voting_summaries:
-    cron: "*/15 * * * * Pacific/Auckland" # Runs every half an hour
+    cron: "*/15 * * * * America/Los_Angeles" # Runs every half an hour
     class: SendRankSummaries
+    enabled: false

--- a/db/migrate/20210224034724_create_report_recipients.rb
+++ b/db/migrate/20210224034724_create_report_recipients.rb
@@ -1,0 +1,10 @@
+class CreateReportRecipients < ActiveRecord::Migration[6.0]
+  def change
+    create_table :report_recipients do |t|
+      t.string :report
+      t.string :email_address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210224035800_add_report_emails.rb
+++ b/db/migrate/20210224035800_add_report_emails.rb
@@ -1,0 +1,10 @@
+class AddReportEmails < ActiveRecord::Migration[6.0]
+  def up
+    ReportRecipient.create(report: "nomination", email_address: $nomination_reports_email)
+    ReportRecipient.create(report: "membership", email_address: $membership_reports_email)
+  end
+
+  def down
+    ReportRecipient.delete_all
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -476,54 +476,6 @@ ALTER SEQUENCE public.notes_id_seq OWNED BY public.notes.id;
 
 
 --
--- Name: operators; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.operators (
-    id bigint NOT NULL,
-    email character varying DEFAULT ''::character varying NOT NULL,
-    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
-    reset_password_token character varying,
-    reset_password_sent_at timestamp without time zone,
-    remember_created_at timestamp without time zone,
-    sign_in_count integer DEFAULT 0 NOT NULL,
-    current_sign_in_at timestamp without time zone,
-    last_sign_in_at timestamp without time zone,
-    current_sign_in_ip inet,
-    last_sign_in_ip inet,
-    confirmation_token character varying,
-    confirmed_at timestamp without time zone,
-    confirmation_sent_at timestamp without time zone,
-    unconfirmed_email character varying,
-    failed_attempts integer DEFAULT 0 NOT NULL,
-    unlock_token character varying,
-    locked_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    hugo_admin boolean DEFAULT false NOT NULL
-);
-
-
---
--- Name: operators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.operators_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: operators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.operators_id_seq OWNED BY public.operators.id;
-
-
---
 -- Name: orders; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -665,6 +617,54 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: supports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.supports (
+    id bigint NOT NULL,
+    email character varying DEFAULT ''::character varying NOT NULL,
+    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
+    reset_password_token character varying,
+    reset_password_sent_at timestamp without time zone,
+    remember_created_at timestamp without time zone,
+    sign_in_count integer DEFAULT 0 NOT NULL,
+    current_sign_in_at timestamp without time zone,
+    last_sign_in_at timestamp without time zone,
+    current_sign_in_ip inet,
+    last_sign_in_ip inet,
+    confirmation_token character varying,
+    confirmed_at timestamp without time zone,
+    confirmation_sent_at timestamp without time zone,
+    unconfirmed_email character varying,
+    failed_attempts integer DEFAULT 0 NOT NULL,
+    unlock_token character varying,
+    locked_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    hugo_admin boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: supports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.supports_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: supports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.supports_id_seq OWNED BY public.supports.id;
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -780,13 +780,6 @@ ALTER TABLE ONLY public.notes ALTER COLUMN id SET DEFAULT nextval('public.notes_
 
 
 --
--- Name: operators id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.operators ALTER COLUMN id SET DEFAULT nextval('public.operators_id_seq'::regclass);
-
-
---
 -- Name: orders id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -812,6 +805,13 @@ ALTER TABLE ONLY public.report_recipients ALTER COLUMN id SET DEFAULT nextval('p
 --
 
 ALTER TABLE ONLY public.reservations ALTER COLUMN id SET DEFAULT nextval('public.reservations_id_seq'::regclass);
+
+
+--
+-- Name: supports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.supports ALTER COLUMN id SET DEFAULT nextval('public.supports_id_seq'::regclass);
 
 
 --
@@ -918,14 +918,6 @@ ALTER TABLE ONLY public.notes
 
 
 --
--- Name: operators operators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.operators
-    ADD CONSTRAINT operators_pkey PRIMARY KEY (id);
-
-
---
 -- Name: orders orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -963,6 +955,14 @@ ALTER TABLE ONLY public.reservations
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: supports supports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.supports
+    ADD CONSTRAINT supports_pkey PRIMARY KEY (id);
 
 
 --
@@ -1072,34 +1072,6 @@ CREATE INDEX index_notes_on_user_id ON public.notes USING btree (user_id);
 
 
 --
--- Name: index_operators_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_operators_on_confirmation_token ON public.operators USING btree (confirmation_token);
-
-
---
--- Name: index_operators_on_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_operators_on_email ON public.operators USING btree (email);
-
-
---
--- Name: index_operators_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_operators_on_reset_password_token ON public.operators USING btree (reset_password_token);
-
-
---
--- Name: index_operators_on_unlock_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_operators_on_unlock_token ON public.operators USING btree (unlock_token);
-
-
---
 -- Name: index_orders_on_membership_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1132,6 +1104,34 @@ CREATE INDEX index_ranks_on_reservation_id ON public.ranks USING btree (reservat
 --
 
 CREATE UNIQUE INDEX index_reservations_on_membership_number ON public.reservations USING btree (membership_number);
+
+
+--
+-- Name: index_supports_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_supports_on_confirmation_token ON public.supports USING btree (confirmation_token);
+
+
+--
+-- Name: index_supports_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_supports_on_email ON public.supports USING btree (email);
+
+
+--
+-- Name: index_supports_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_supports_on_reset_password_token ON public.supports USING btree (reset_password_token);
+
+
+--
+-- Name: index_supports_on_unlock_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_supports_on_unlock_token ON public.supports USING btree (unlock_token);
 
 
 --
@@ -1318,10 +1318,12 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200324223922'),
 ('20200525204858'),
 ('20200629100946'),
-('20200704235959'),
 ('20200717051724'),
 ('20200717081753'),
 ('20200719215504'),
 ('20200720235919'),
 ('20200724003813'),
-('20210224034724');
+('20210224034724'),
+('20210224035800');
+
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -476,6 +476,54 @@ ALTER SEQUENCE public.notes_id_seq OWNED BY public.notes.id;
 
 
 --
+-- Name: operators; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.operators (
+    id bigint NOT NULL,
+    email character varying DEFAULT ''::character varying NOT NULL,
+    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
+    reset_password_token character varying,
+    reset_password_sent_at timestamp without time zone,
+    remember_created_at timestamp without time zone,
+    sign_in_count integer DEFAULT 0 NOT NULL,
+    current_sign_in_at timestamp without time zone,
+    last_sign_in_at timestamp without time zone,
+    current_sign_in_ip inet,
+    last_sign_in_ip inet,
+    confirmation_token character varying,
+    confirmed_at timestamp without time zone,
+    confirmation_sent_at timestamp without time zone,
+    unconfirmed_email character varying,
+    failed_attempts integer DEFAULT 0 NOT NULL,
+    unlock_token character varying,
+    locked_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    hugo_admin boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: operators_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.operators_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: operators_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.operators_id_seq OWNED BY public.operators.id;
+
+
+--
 -- Name: orders; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -543,6 +591,38 @@ ALTER SEQUENCE public.ranks_id_seq OWNED BY public.ranks.id;
 
 
 --
+-- Name: report_recipients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.report_recipients (
+    id bigint NOT NULL,
+    report character varying,
+    email_address character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: report_recipients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.report_recipients_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: report_recipients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.report_recipients_id_seq OWNED BY public.report_recipients.id;
+
+
+--
 -- Name: reservations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -582,54 +662,6 @@ ALTER SEQUENCE public.reservations_id_seq OWNED BY public.reservations.id;
 CREATE TABLE public.schema_migrations (
     version character varying NOT NULL
 );
-
-
---
--- Name: supports; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.supports (
-    id bigint NOT NULL,
-    email character varying DEFAULT ''::character varying NOT NULL,
-    encrypted_password character varying DEFAULT ''::character varying NOT NULL,
-    reset_password_token character varying,
-    reset_password_sent_at timestamp without time zone,
-    remember_created_at timestamp without time zone,
-    sign_in_count integer DEFAULT 0 NOT NULL,
-    current_sign_in_at timestamp without time zone,
-    last_sign_in_at timestamp without time zone,
-    current_sign_in_ip inet,
-    last_sign_in_ip inet,
-    confirmation_token character varying,
-    confirmed_at timestamp without time zone,
-    confirmation_sent_at timestamp without time zone,
-    unconfirmed_email character varying,
-    failed_attempts integer DEFAULT 0 NOT NULL,
-    unlock_token character varying,
-    locked_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    hugo_admin boolean DEFAULT false NOT NULL
-);
-
-
---
--- Name: supports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.supports_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: supports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.supports_id_seq OWNED BY public.supports.id;
 
 
 --
@@ -748,6 +780,13 @@ ALTER TABLE ONLY public.notes ALTER COLUMN id SET DEFAULT nextval('public.notes_
 
 
 --
+-- Name: operators id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operators ALTER COLUMN id SET DEFAULT nextval('public.operators_id_seq'::regclass);
+
+
+--
 -- Name: orders id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -762,17 +801,17 @@ ALTER TABLE ONLY public.ranks ALTER COLUMN id SET DEFAULT nextval('public.ranks_
 
 
 --
+-- Name: report_recipients id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report_recipients ALTER COLUMN id SET DEFAULT nextval('public.report_recipients_id_seq'::regclass);
+
+
+--
 -- Name: reservations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.reservations ALTER COLUMN id SET DEFAULT nextval('public.reservations_id_seq'::regclass);
-
-
---
--- Name: supports id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.supports ALTER COLUMN id SET DEFAULT nextval('public.supports_id_seq'::regclass);
 
 
 --
@@ -879,6 +918,14 @@ ALTER TABLE ONLY public.notes
 
 
 --
+-- Name: operators operators_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.operators
+    ADD CONSTRAINT operators_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: orders orders_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -895,6 +942,14 @@ ALTER TABLE ONLY public.ranks
 
 
 --
+-- Name: report_recipients report_recipients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.report_recipients
+    ADD CONSTRAINT report_recipients_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: reservations reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -908,14 +963,6 @@ ALTER TABLE ONLY public.reservations
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
--- Name: supports supports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.supports
-    ADD CONSTRAINT supports_pkey PRIMARY KEY (id);
 
 
 --
@@ -1025,6 +1072,34 @@ CREATE INDEX index_notes_on_user_id ON public.notes USING btree (user_id);
 
 
 --
+-- Name: index_operators_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operators_on_confirmation_token ON public.operators USING btree (confirmation_token);
+
+
+--
+-- Name: index_operators_on_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operators_on_email ON public.operators USING btree (email);
+
+
+--
+-- Name: index_operators_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operators_on_reset_password_token ON public.operators USING btree (reset_password_token);
+
+
+--
+-- Name: index_operators_on_unlock_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_operators_on_unlock_token ON public.operators USING btree (unlock_token);
+
+
+--
 -- Name: index_orders_on_membership_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1057,34 +1132,6 @@ CREATE INDEX index_ranks_on_reservation_id ON public.ranks USING btree (reservat
 --
 
 CREATE UNIQUE INDEX index_reservations_on_membership_number ON public.reservations USING btree (membership_number);
-
-
---
--- Name: index_supports_on_confirmation_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_supports_on_confirmation_token ON public.supports USING btree (confirmation_token);
-
-
---
--- Name: index_supports_on_email; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_supports_on_email ON public.supports USING btree (email);
-
-
---
--- Name: index_supports_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_supports_on_reset_password_token ON public.supports USING btree (reset_password_token);
-
-
---
--- Name: index_supports_on_unlock_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_supports_on_unlock_token ON public.supports USING btree (unlock_token);
 
 
 --
@@ -1271,10 +1318,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200324223922'),
 ('20200525204858'),
 ('20200629100946'),
+('20200704235959'),
 ('20200717051724'),
 ('20200717081753'),
 ('20200719215504'),
 ('20200720235919'),
-('20200724003813');
-
-
+('20200724003813'),
+('20210224034724');

--- a/spec/factories/report_recipients.rb
+++ b/spec/factories/report_recipients.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :report_recipient do
+    report { "MyString" }
+    email_address { "MyString" }
+  end
+end

--- a/spec/models/report_recipient_spec.rb
+++ b/spec/models/report_recipient_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ReportRecipient, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- Add a model for report recipients
- Stop checking structure.sql
- Switch to using database report mails for nom/mem
- Disable all reports except the membership one

Managing reports via a deployment is a pain; this moves it into an admin table
