### PR TITLE
Feature: non-public membership types (like art show)

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -16,6 +16,11 @@
 
 class MembershipsController < ApplicationController
   def index
-    @offers = MembershipOffer.options.select(&:offer_for_purchase?)
+    if support_signed_in?
+      @offers = MembershipOffer.options
+    else
+      @offers = MembershipOffer.options.select(&:offer_for_purchase?)
+    end
+
   end
 end

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -16,6 +16,6 @@
 
 class MembershipsController < ApplicationController
   def index
-    @offers = MembershipOffer.options
+    @offers = MembershipOffer.options.select(&:offer_for_purchase?)
   end
 end

--- a/app/javascript/sprinkles/clipboard.js
+++ b/app/javascript/sprinkles/clipboard.js
@@ -1,0 +1,15 @@
+import $ from "jquery";
+import * as Clipboard from "clipboard/dist/clipboard";
+
+$(document).ready(() => {
+  var clipboard = new Clipboard(".clipboard-btn");
+
+  clipboard.on("success", e => {
+    var currentText = e.trigger.innerText;
+    e.trigger.innerText = "Copied";
+
+    setTimeout(() => {
+      e.trigger.innerText = currentText;
+    }, 2000);
+  });
+});

--- a/app/javascript/sprinkles/index.js
+++ b/app/javascript/sprinkles/index.js
@@ -21,6 +21,7 @@ import $ from 'jquery';
 import 'datatables.net-bs4';
 import 'popper.js';
 import 'bootstrap';
+import "./clipboard";
 
 $(document).ready(() => {
   // DataTable plugin for searchable and sortable tables

--- a/app/queries/membership_offer.rb
+++ b/app/queries/membership_offer.rb
@@ -71,4 +71,8 @@ class MembershipOffer
   def dob_required?
     membership.dob_required?
   end
+
+  def offer_for_purchase?
+    ! membership.private_membership_option
+  end
 end

--- a/app/views/memberships/index.html.erb
+++ b/app/views/memberships/index.html.erb
@@ -24,12 +24,19 @@
     <% @offers.each do |offer| %>
       <div class="col-sm-12 col-md-6 col-lg-4 mb-3">
         <%= render("membership_card", offer: offer) do %>
-
-          <%= link_to(
-            "Reserve #{offer.membership}",
-            new_reservation_path(offer: offer.hash),
-            class: %w(btn btn-lg btn-block btn-primary),
-          ) %>
+          <% if offer.offer_for_purchase? %>
+            <%= link_to(
+              "Reserve #{offer.membership}",
+              new_reservation_path(offer: offer.hash),
+              class: %w(btn btn-lg btn-block btn-primary),
+            ) %>
+          <% else %>
+            <button class="clipboard-btn btn btn-lg btn-block btn-primary"
+                    data-clipboard-action="copy"
+                    data-clipboard-text="<%= new_reservation_url(offer: offer.hash) %>">
+              Copy URL
+            </button>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/db/migrate/20210916230829_add_private_membership.rb
+++ b/db/migrate/20210916230829_add_private_membership.rb
@@ -1,0 +1,9 @@
+class AddPrivateMembership < ActiveRecord::Migration[6.1]
+  def up
+    add_column :memberships, :private_membership_option, :boolean, default: false, null: false
+  end
+
+  def down
+    remove_column :memberships, :private_membership_option
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -461,7 +461,8 @@ CREATE TABLE public.memberships (
     can_nominate boolean DEFAULT false NOT NULL,
     can_site_select boolean DEFAULT false NOT NULL,
     dob_required boolean DEFAULT false NOT NULL,
-    display_name character varying
+    display_name character varying,
+    private_membership_option boolean DEFAULT false NOT NULL
 );
 
 
@@ -1477,6 +1478,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210105055602'),
 ('20210224001734'),
 ('20210224034724'),
-('20210224035800');
+('20210224035800'),
+('20210916230829');
 
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@rails/ujs": "^6.0.3",
     "@rails/webpacker": "^4.0.7",
     "bootstrap": "^4.5.0",
+    "clipboard": "^2.0.8",
     "datatables.net-bs4": "^1.10.21",
     "eslint": "^7.1.0",
     "eslint-config-airbnb-base": "*",

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe Membership, type: :model do
 
   it { is_expected.to be_valid }
 
-
-
   describe "#active_reservations" do
     it "can access reservations directly" do
       expect(model.reservations.count).to be(1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,6 +2015,15 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
+clipboard@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.8.tgz#ffc6c103dd2967a83005f3f61976aa4655a4cdba"
+  integrity sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -2717,6 +2726,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3788,6 +3802,13 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.10"
     minimatch "~3.0.2"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.2:
   version "4.2.6"
@@ -7088,6 +7109,11 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
 selfsigned@^1.10.8:
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.8.tgz#0d17208b7d12c33f8eac85c41835f27fc3d81a30"
@@ -7818,6 +7844,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
- feat: add support for non-public membership types
- feat: show not-openly-for-sale offers to support

Support will see offers that are otherwise not for sale, and instead of
a "reserve" button they'll get a "Copy URL" button, which will give them
a URL that they can send to parties that should have access to the
special membership.

To create a membership like this, use this code:

```ruby
Membership.create!(
  name: "artshow",
  # ... other attributes,
  private_membership_option: true,
)
```
